### PR TITLE
Support for ReversalFlag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ build/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
+Gemfile.lock
 # .ruby-version
 # .ruby-gemset
 

--- a/jemquarie.gemspec
+++ b/jemquarie.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler",     '>= 1.3'
   spec.add_development_dependency "rake",        '>= 10.3.0'
   spec.add_development_dependency "fakeweb",     '>= 1.3.0'
-  spec.add_development_dependency "rspec",       '>= 2.14.0'
+  spec.add_development_dependency "rspec",       '~> 2'
 end

--- a/lib/jemquarie/parser/cash_transactions.rb
+++ b/lib/jemquarie/parser/cash_transactions.rb
@@ -27,6 +27,7 @@ private
           :amount             => transaction["DebitCredit"] == 'C' ? transaction["Amount"] : ('-' + transaction["Amount"]),
           :type_name          => translate_transaction_type(transaction["TransactionType"]),
           :description        => transaction["Narrative"],
+          :reverse            => (transaction["ReversalFlag"] == 'Y'),
           :meta_data => {
             :updated_at       => Time.parse(transaction["DateModified"] + " UTC")
           }

--- a/lib/jemquarie/parser/cash_transactions.rb
+++ b/lib/jemquarie/parser/cash_transactions.rb
@@ -27,7 +27,7 @@ private
           :amount             => transaction["DebitCredit"] == 'C' ? transaction["Amount"] : ('-' + transaction["Amount"]),
           :type_name          => translate_transaction_type(transaction["TransactionType"]),
           :description        => transaction["Narrative"],
-          :reverse            => (transaction["ReversalFlag"] == 'Y'),
+          :reverse            => transaction["ReversalFlag"] == 'Y',
           :meta_data => {
             :updated_at       => Time.parse(transaction["DateModified"] + " UTC")
           }

--- a/spec/files/transactions/transactions.xml
+++ b/spec/files/transactions/transactions.xml
@@ -38,6 +38,18 @@
     &lt;/yourclientsTransaction&gt;
     &lt;yourclientsTransaction&gt;
       &lt;AccountNumber&gt;121741987&lt;/AccountNumber&gt;
+      &lt;TransactionDate&gt;2008-12-23 00:00:00.0&lt;/TransactionDate&gt;
+      &lt;ReversalFlag&gt;Y&lt;/ReversalFlag&gt;
+      &lt;DebitCredit&gt;D&lt;/DebitCredit&gt;
+      &lt;TransactionType&gt;BP&lt;/TransactionType&gt;
+      &lt;TransactionId&gt;0132058314&lt;/TransactionId&gt;
+      &lt;Amount&gt;2.4100&lt;/Amount&gt;
+      &lt;Narrative&gt;BPAY TO MACQUARIE CMT&lt;/Narrative&gt;
+      &lt;DateModified&gt;2008-12-23 04:14:26.683&lt;/DateModified&gt;
+      &lt;TransactionCategory&gt;WTHD&lt;/TransactionCategory&gt;
+    &lt;/yourclientsTransaction&gt;
+    &lt;yourclientsTransaction&gt;
+      &lt;AccountNumber&gt;121741987&lt;/AccountNumber&gt;
       &lt;TransactionDate&gt;2009-02-17 00:00:00.0&lt;/TransactionDate&gt;
       &lt;ReversalFlag&gt;N&lt;/ReversalFlag&gt;
       &lt;DebitCredit&gt;D&lt;/DebitCredit&gt;

--- a/spec/lib/importer_spec.rb
+++ b/spec/lib/importer_spec.rb
@@ -19,7 +19,7 @@ describe Jemquarie::Importer do
     end
     it "should work" do
       expect(@result).to be_kind_of Array
-      expect(@result).to have(185).items
+      expect(@result).to have(186).items
 
       first_item = @result.first
       expect(first_item[:foreign_identifier]).to eq("0132058314")
@@ -27,6 +27,7 @@ describe Jemquarie::Importer do
       expect(first_item[:amount]).to eq("-2.4100")
       expect(first_item[:type_name]).to eq("B-PAY WITHDRAWAL")
       expect(first_item[:description]).to eq("BPAY TO MACQUARIE CMT")
+      expect(first_item[:reverse]).to eq(false)
       expect(first_item[:meta_data][:updated_at]).to eq(Time.parse("2008-12-19 04:14:26.683 UTC"))
 
       last_item = @result.last
@@ -35,8 +36,20 @@ describe Jemquarie::Importer do
       expect(last_item[:amount]).to eq("0.0600")
       expect(last_item[:type_name]).to eq("INTEREST PAID")
       expect(last_item[:description]).to eq("CASH MANAGEMENT SERVICE INTEREST PAID")
+      expect(first_item[:reverse]).to eq(false)
       expect(last_item[:meta_data][:updated_at]).to eq(Time.parse("2014-05-01 01:36:42.763 UTC"))
+
+
+      reverse_item = @result.detect{ |row| row[:reverse] == true }
+      expect(reverse_item[:foreign_identifier]).to eq(first_item[:foreign_identifier])
+      expect(reverse_item[:date_time]).to eq(Time.parse("2008-12-23 00:00:00 UTC"))
+      expect(reverse_item[:amount]).to eq(first_item[:amount])
+      expect(reverse_item[:type_name]).to eq(first_item[:type_name])
+      expect(reverse_item[:description]).to eq(first_item[:description])
+      expect(reverse_item[:reverse]).to eq(true)
+      expect(reverse_item[:meta_data][:updated_at]).to eq(Time.parse("2008-12-23 04:14:26.683 UTC"))
     end
+
   end
 
   describe "single transaction success" do


### PR DESCRIPTION
Sometimes transactions become reversed. Macquarie sends those again with the ReversalFlag set to true.